### PR TITLE
count も batchWrite もそれぞれ普通に RCU/WCU 使う

### DIFF
--- a/dynamo/src/main/java/com/example/visualp/system002/accessor/dynamodbmapper/DynamoDbMapperAccessor.java
+++ b/dynamo/src/main/java/com/example/visualp/system002/accessor/dynamodbmapper/DynamoDbMapperAccessor.java
@@ -1,6 +1,7 @@
 package com.example.visualp.system002.accessor.dynamodbmapper;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
@@ -9,11 +10,13 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
 import com.example.visualp.system002.accessor.dynamodbmapper.entity.Item;
 import com.example.visualp.system002.accessor.dynamodbmapper.entity.ItemExpressions;
+import com.example.visualp.system002.accessor.dynamodbmapper.entity.ItemFactory;
 import com.example.visualp.system002.accessor.dynamodbmapper.entity.Items;
 import com.example.visualp.system002.config.DynamoDbMapperProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -61,5 +64,21 @@ public class DynamoDbMapperAccessor {
     item.setSort(sort);
 
     return mapper.load(item);
+  }
+
+  public long count(@Nonnull String id) {
+    DynamoDBMapper mapper = DynamoDbMapperProvider.provide();
+
+    // 結局、内部でクエリー発行しているので 4kb 制限での RCU 使ってる。
+    return mapper.count(Item.class, ItemExpressions.queryCase1(id));
+  }
+
+  public void batchWrite(@Nonnull String id) {
+    DynamoDBMapper mapper = DynamoDbMapperProvider.provide();
+
+    List<FailedBatch> failedBatches = mapper.batchWrite(
+        ItemFactory.create(id, 60, 100),
+        new ArrayList<>()
+    );
   }
 }

--- a/dynamo/src/main/java/com/example/visualp/system002/accessor/dynamodbmapper/entity/ItemFactory.java
+++ b/dynamo/src/main/java/com/example/visualp/system002/accessor/dynamodbmapper/entity/ItemFactory.java
@@ -1,0 +1,22 @@
+package com.example.visualp.system002.accessor.dynamodbmapper.entity;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
+
+public class ItemFactory {
+
+  @Nonnull
+  public static List<Item> create(@Nonnull String id, int sortStart, int sortEnd) {
+    return IntStream.rangeClosed(sortStart, sortEnd)
+        .mapToObj(v -> {
+          Item item = new Item();
+
+          item.setId(id);
+          item.setSort(v);
+          return item;
+        })
+        .collect(Collectors.toList());
+  }
+}

--- a/dynamo/src/main/java/com/example/visualp/system002/facade/StudyFacade.java
+++ b/dynamo/src/main/java/com/example/visualp/system002/facade/StudyFacade.java
@@ -6,5 +6,9 @@ public interface StudyFacade {
 
   void studyRead(@Nonnull String id) throws Exception;
 
+  void studyCount(@Nonnull String id) throws Exception;
+
+  void batchWrite(@Nonnull String id) throws Exception;
+
   void studyAdd();
 }

--- a/dynamo/src/main/java/com/example/visualp/system002/facade/impl/StudyFacadeImpl.java
+++ b/dynamo/src/main/java/com/example/visualp/system002/facade/impl/StudyFacadeImpl.java
@@ -20,6 +20,16 @@ public class StudyFacadeImpl implements StudyFacade {
   }
 
   @Override
+  public void studyCount(@Nonnull String id) throws Exception {
+    mapperAccessor.count(id);
+  }
+
+  @Override
+  public void batchWrite(@Nonnull String id) throws Exception {
+    mapperAccessor.batchWrite(id);
+  }
+
+  @Override
   public void studyAdd() {
     accessor.update();
   }

--- a/dynamo/src/main/java/com/example/visualp/system002/resources/StudyResources.java
+++ b/dynamo/src/main/java/com/example/visualp/system002/resources/StudyResources.java
@@ -27,6 +27,28 @@ public class StudyResources {
         .build();
   }
 
+  @Path("count/{id}")
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response simpleCount(@PathParam("id") String id) throws Exception {
+    facade.studyCount(id);
+
+    return Response
+        .noContent()
+        .build();
+  }
+
+  @Path("batchWrite/{id}")
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response batchWrite(@PathParam("id") String id) throws Exception {
+    facade.batchWrite(id);
+
+    return Response
+        .noContent()
+        .build();
+  }
+
   @Path("add")
   @POST
   @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
count は query を内部で発行しているので query

batchWrite は 25 個ずつ RestClient で送信しているが
裏では 1 個ずつ Write が走っているだけに思われる。RCU が普通に 1 Write につき 1 つ使われているから。

[メモとして]
・ 25 個ずつ区切った後、サイズ(おそらく1M) を超えているエラーが RestClient から返却された場合、
サイズを調整して再度リクエストを送信している
https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java#L1177

・ Write と Delete のリクエストは同時に発行されうる
https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java#L1136
※ RequestItems に Write/Delete のリクエスト内容をつっこんだ後、25 ずつ subMap で分割して RestClient で送信している。