### PR TITLE
sigv4 対応調査

### DIFF
--- a/s3/.gitignore
+++ b/s3/.gitignore
@@ -1,0 +1,26 @@
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+/**/target/
+
+### NetBeans ###
+/nbproject/private/
+/build/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/

--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -1,0 +1,95 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.visualp.system010</groupId>
+  <artifactId>system010</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <packaging>war</packaging>
+
+  <name>system010</name>
+
+  <build>
+    <finalName>system010</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
+        <version>2.2</version>
+        <configuration>
+          <server>tomcat-localhost</server>
+          <path>/</path>
+          <username>admin</username>
+          <password>admin</password>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>2.21</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-utils</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.11.510</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.11.510</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/s3/src/main/java/com/example/visualp/system010/App.java
+++ b/s3/src/main/java/com/example/visualp/system010/App.java
@@ -1,0 +1,37 @@
+package com.example.visualp.system010;
+
+import com.example.visualp.system010.accessor.s3.S3Accessor;
+import com.example.visualp.system010.config.S3Provider;
+import com.example.visualp.system010.facade.StudyFacade;
+import com.example.visualp.system010.facade.impl.StudyFacadeImpl;
+import com.example.visualp.system010.resources.StudyResources;
+import javax.ws.rs.ApplicationPath;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+
+@ApplicationPath("/")
+public class App extends ResourceConfig {
+
+  private boolean onBoot = false;
+
+  public App() {
+
+    packages(this.getClass().getPackage().getName());
+
+    register(new AbstractBinder() {
+      @Override
+      protected void configure() {
+
+        // Accessor
+        bind(S3Provider.class).to(S3Provider.class);
+        bind(S3Accessor.class).to(S3Accessor.class);
+
+        // Facade
+        bind(StudyFacadeImpl.class).to(StudyFacade.class);
+
+        // Resources
+        bind(StudyResources.class).to(StudyResources.class);
+      }
+    });
+  }
+}

--- a/s3/src/main/java/com/example/visualp/system010/accessor/s3/S3Accessor.java
+++ b/s3/src/main/java/com/example/visualp/system010/accessor/s3/S3Accessor.java
@@ -1,0 +1,15 @@
+package com.example.visualp.system010.accessor.s3;
+
+import static com.example.visualp.system010.config.Const.S3_BUCKET_NAME;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.example.visualp.system010.config.S3Provider;
+
+public class S3Accessor {
+
+  public String getLocation() {
+    AmazonS3 client = S3Provider.provide();
+
+    return client.getBucketLocation(S3_BUCKET_NAME);
+  }
+}

--- a/s3/src/main/java/com/example/visualp/system010/config/AwsCredentialsProvider.java
+++ b/s3/src/main/java/com/example/visualp/system010/config/AwsCredentialsProvider.java
@@ -1,0 +1,15 @@
+package com.example.visualp.system010.config;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import javax.annotation.Nonnull;
+
+public class AwsCredentialsProvider {
+
+  @Nonnull
+  public static BasicAWSCredentials provide() {
+    return new BasicAWSCredentials(
+        Const.AWS_ACCESS_KEY,
+        Const.AWS_SECRET_KEY
+    );
+  }
+}

--- a/s3/src/main/java/com/example/visualp/system010/config/Const.java
+++ b/s3/src/main/java/com/example/visualp/system010/config/Const.java
@@ -1,0 +1,13 @@
+package com.example.visualp.system010.config;
+
+import com.amazonaws.regions.Regions;
+
+public class Const {
+
+  public static final String AWS_ACCESS_KEY = "";
+  public static final String AWS_SECRET_KEY = "";
+
+  public static final Regions REGION = Regions.US_EAST_2;
+
+  public static final String S3_BUCKET_NAME = "umejima-test-sigv4";
+}

--- a/s3/src/main/java/com/example/visualp/system010/config/S3Provider.java
+++ b/s3/src/main/java/com/example/visualp/system010/config/S3Provider.java
@@ -1,0 +1,19 @@
+package com.example.visualp.system010.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import javax.annotation.Nonnull;
+
+public class S3Provider {
+
+  @Nonnull
+  public static AmazonS3 provide() {
+    return AmazonS3ClientBuilder.standard()
+        .withRegion(Const.REGION)
+        .withCredentials(new AWSStaticCredentialsProvider(AwsCredentialsProvider.provide()))
+        .build();
+  }
+}

--- a/s3/src/main/java/com/example/visualp/system010/facade/StudyFacade.java
+++ b/s3/src/main/java/com/example/visualp/system010/facade/StudyFacade.java
@@ -1,0 +1,6 @@
+package com.example.visualp.system010.facade;
+
+public interface StudyFacade {
+
+  void getLocation() throws Exception;
+}

--- a/s3/src/main/java/com/example/visualp/system010/facade/impl/StudyFacadeImpl.java
+++ b/s3/src/main/java/com/example/visualp/system010/facade/impl/StudyFacadeImpl.java
@@ -1,0 +1,18 @@
+package com.example.visualp.system010.facade.impl;
+
+import com.example.visualp.system010.accessor.s3.S3Accessor;
+import com.example.visualp.system010.facade.StudyFacade;
+import javax.inject.Inject;
+
+public class StudyFacadeImpl implements StudyFacade {
+
+  @Inject
+  private S3Accessor accessor;
+
+  @Override
+  public void getLocation() throws Exception {
+    String location = accessor.getLocation();
+
+    System.out.println(location);
+  }
+}

--- a/s3/src/main/java/com/example/visualp/system010/resources/StudyResources.java
+++ b/s3/src/main/java/com/example/visualp/system010/resources/StudyResources.java
@@ -1,0 +1,27 @@
+package com.example.visualp.system010.resources;
+
+import com.example.visualp.system010.facade.StudyFacade;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("study")
+public class StudyResources {
+
+  @Inject
+  private StudyFacade facade;
+
+  @Path("location")
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response s3Get() throws Exception {
+    facade.getLocation();
+
+    return Response
+        .ok()
+        .build();
+  }
+}


### PR DESCRIPTION
[sigv4 対応調査]

1. US_EAST_2 は sigv4 でなければエラーが発生するという情報を元に検証
※ 1.11 系で動き、1.11 未満であれば動かないのであれば検証終わり
⇒ 1.10 系/1.9 系でも動いた

2. sigv4 を調査
* `Java 1.11.x` であれば問題なさそう。
参考: https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/dev/UsingAWSSDK.html#UsingAWSSDK-move-to-Sig4

> 署名バージョン 4 を使用していることはどのように確認できますか。また、どの更新が必要ですか。
> 
> リクエストを署名するために使用する署名バージョンは、通常の場合、クライアント側のツールあるいは SDK によって設定されます。
> デフォルトでは、最新バージョンの AWS SDK は署名バージョン 4 を使用します。サードパーティのソフトウェアについては、お使いのソフトウェアに該当するサポートチームにお問い合わせいただき、必要なバージョンを確認してください。
> Amazon S3 にダイレクト REST コールを送信する場合、アプリケーションを変更して署名バージョン 4 の署名プロセスを使用する必要があります。

> すべての AWS リージョンでは、AWS SDK はデフォルトで署名バージョン 4 を使用してリクエストを認証します。
> 2016 年 5 月以前にリリースされた AWS SDK を使用する場合、次の表に示すように、署名バージョン 4 のリクエストが必要になることがあります。
<br><br>

その他、色々調べてみた結果、
最新の AWS SDK (1.11.x 系) 使っていれば問題ないと思われるので調査は終わる