### PR TITLE
batch application (2) (cron 調査 -> jersey での cron 判断実装まで)

### DIFF
--- a/scheduler-application/jersey/pom.xml
+++ b/scheduler-application/jersey/pom.xml
@@ -77,6 +77,13 @@
       <version>2.4.0</version>
     </dependency>
 
+    <!-- http://www.apache.org/licenses/LICENSE-2.0 -->
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>2.2.3</version>
+    </dependency>
+
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>

--- a/scheduler-application/jersey/pom.xml
+++ b/scheduler-application/jersey/pom.xml
@@ -60,6 +60,18 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <version>2.17</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>hk2-utils</artifactId>
       <version>2.4.0</version>
@@ -69,6 +81,12 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>2.0.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.16.4</version>
     </dependency>
 
     <dependency>

--- a/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/App.java
+++ b/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/App.java
@@ -3,7 +3,10 @@ package com.example.visualp.system19053101;
 import com.example.visualp.system19053101.common.scheduling.ScheduleTask;
 import com.example.visualp.system19053101.common.scheduling.ScheduledTaskHolder;
 import com.example.visualp.system19053101.common.scheduling.ScheduledTaskRegistrar;
+import com.example.visualp.system19053101.facade.ScheduleFacade;
+import com.example.visualp.system19053101.facade.impl.ScheduleFacadeImpl;
 import com.example.visualp.system19053101.resources.HealthCheckResource;
+import com.example.visualp.system19053101.resources.ScheduleResource;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 import javax.ws.rs.ApplicationPath;
@@ -24,8 +27,12 @@ public class App extends ResourceConfig {
       @Override
       protected void configure() {
 
+        // Facade
+        bind(ScheduleFacadeImpl.class).to(ScheduleFacade.class);
+
         // Resources
         bind(HealthCheckResource.class).to(HealthCheckResource.class);
+        bind(ScheduleResource.class).to(ScheduleResource.class);
 
         bind(registrar).to(ScheduledTaskHolder.class);
       }

--- a/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/facade/ScheduleFacade.java
+++ b/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/facade/ScheduleFacade.java
@@ -1,0 +1,9 @@
+package com.example.visualp.system19053101.facade;
+
+import com.example.visualp.system19053101.resources.schema.ScheduleSchema;
+import javax.annotation.Nonnull;
+
+public interface ScheduleFacade {
+
+  void add(@Nonnull String cronTab);
+}

--- a/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/facade/impl/ScheduleFacadeImpl.java
+++ b/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/facade/impl/ScheduleFacadeImpl.java
@@ -1,12 +1,23 @@
 package com.example.visualp.system19053101.facade.impl;
 
 import com.example.visualp.system19053101.facade.ScheduleFacade;
+import java.text.ParseException;
+import java.util.TimeZone;
 import javax.annotation.Nonnull;
+import org.quartz.CronExpression;
 
 public class ScheduleFacadeImpl implements ScheduleFacade {
 
   @Override
   public void add(@Nonnull String cronTab) {
-    System.out.println(cronTab);
+    CronExpression expression;
+
+    try {
+      // 秒未サポートなら、先頭に "* " を追加すれば OK
+      expression = new CronExpression(cronTab);
+    } catch (ParseException e) {
+      throw new IllegalArgumentException(e);
+    }
+    // この時点で cron tab 登録可能なものなので dynamodb に登録して OK
   }
 }

--- a/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/facade/impl/ScheduleFacadeImpl.java
+++ b/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/facade/impl/ScheduleFacadeImpl.java
@@ -1,0 +1,12 @@
+package com.example.visualp.system19053101.facade.impl;
+
+import com.example.visualp.system19053101.facade.ScheduleFacade;
+import javax.annotation.Nonnull;
+
+public class ScheduleFacadeImpl implements ScheduleFacade {
+
+  @Override
+  public void add(@Nonnull String cronTab) {
+    System.out.println(cronTab);
+  }
+}

--- a/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/resources/ScheduleResource.java
+++ b/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/resources/ScheduleResource.java
@@ -1,0 +1,31 @@
+package com.example.visualp.system19053101.resources;
+
+import com.example.visualp.system19053101.facade.ScheduleFacade;
+import com.example.visualp.system19053101.resources.schema.ScheduleSchema;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("schedule")
+public class ScheduleResource {
+
+  @Inject
+  private ScheduleFacade facade;
+
+  @POST
+  @Path("add")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response schedule(ScheduleSchema schema) throws Exception {
+
+    facade.add(schema.getCronTab());
+
+    return Response
+        .ok()
+        .build();
+  }
+}

--- a/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/resources/schema/ScheduleSchema.java
+++ b/scheduler-application/jersey/src/main/java/com/example/visualp/system19053101/resources/schema/ScheduleSchema.java
@@ -1,0 +1,9 @@
+package com.example.visualp.system19053101.resources.schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+public class ScheduleSchema {
+  private String cronTab;
+}

--- a/scheduler-application/spring/system19052501/src/main/java/com/example/visualp/system19052501/schedule/ScheduledTasks.java
+++ b/scheduler-application/spring/system19052501/src/main/java/com/example/visualp/system19052501/schedule/ScheduledTasks.java
@@ -30,7 +30,7 @@ public class ScheduledTasks {
   */
 
   // 月曜日から金曜日の間、5秒間隔で実行する
-  @Scheduled(cron="*/5 * * * * MON-FRI")
+  @Scheduled(cron="*/5 * * * * *")
   public void task4() {
     System.out.println(now() + "Run task A. ThreadId:" + Thread.currentThread().getId());
   }


### PR DESCRIPTION
<h2> cron expression </h2>

https://en.wikipedia.org/wiki/Cron

<br><br>
<h3> Standard 仕様 </h3>

* 分/時/月内の日/月/曜日 の 5 項目 + Command
```
# ┌───────────── minute (0 - 59)
# │ ┌───────────── hour (0 - 23)
# │ │ ┌───────────── day of the month (1 - 31)
# │ │ │ ┌───────────── month (1 - 12)
# │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
# │ │ │ │ │                                   7 is also Sunday on some systems)
# │ │ │ │ │
# │ │ │ │ │
# * * * * * command to execute
```

* `,` (カンマ): リストの項目を区切るために使用 (MON,WED =月水)
※ 全項目に使用可能

* `-` (ハイフン): 範囲を定義するために使用 (1–20 = 1～20分)
※ 全項目に使用可能

<br><br>
<h3> Non-Standard 仕様 </h3>

* `/` (スラッシュ): 増分を指定するために使用 (*/5 = 5分ごと)
※ wiki には記載がないが AWS では曜日項目以外に使用可能

* `L` (エル): "last"を表すために仕様 (月または週の最終日を指す)
※ 月内の日/曜日項目のみ使用可能

* `W` (ダブリュー): 最も近い平日を指定するために使用 (15W = 15 日からみて、最も近い平日を指す)
※ 月内の日項目のみ

* `?` (疑問符): wiki 上では特定の実装向けとある
  ※ 特定の実装向けには、実行時に置き換えている
  参考: http://www.nncron.ru/help/EN/working/cron-format.htm#STARTTIME

  ※ AWS 上では月内の日項目/曜日項目のみ (制約として) 使用可能で、任意という意味合いを持つ
  参考(CloudWatch):
  https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/events/ScheduledEvents.html
  参考(Lambda): https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
  参考: (System Manager): https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/reference-cron-and-rate-expressions.html

* `＃` (シャープ): 月の指定された曜日の特定する (3#2 は、月の第 2 火曜日を示す)
※ 曜日項目のみ使用可能

* 6 項目目 (年) 
  ※ wiki では 5項目までで 6 項目目は `This field is not supported in standard/default implementations.` とある (non-standard とある)
  ※ AWS では 年をサポートしている (分/時/月内の日/月/曜日/年)

* `H` (エイチ): 「ハッシュ」値が代用されることを示す
※ (wiki を見る限りおそらく) Jenkins のみで使用されている。

<br>
<h3> AWS では </h3>

↑の non-standard で `H` 以外をサポート
※ 6項目 (分/時/月内の日/月/曜日/年) で、最少単位が 1 分
※ 基本的に統一されているように見えるものの、一部では `#` が使えると明示的に記載されていないものもあった。

<br>
<h3> Quartz (Javaアプリケーションへの統合 job scheduling ライブラリ) では </h3> 

↑の non-standard で `H` 以外をサポート
参考: http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html
※ 7 項目 (秒/分/時/月内の日/月/曜日/年) で、最初単位が 1 秒
※ 年は任意項目としてサポート

<br>
<h3> Spring では </h3> 

さわってみた感じ、non-standard もできて `?` も `*` でもできて、かなり色々な面でサポートしている

<br>
<h3> 結論として </h3> 

Quartz ライブラリを使う方向で進みたい。
外部への説明としては、Quartz ドキュメント (http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) を見せて秒はサポートしないとか？

もしくは、外向け説明としては AWS でドキュメント定義 (例: https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/events/ScheduledEvents.html) しているように各々の説明を記載するとかになるのかも。

※ AWS でサポートしているものを受け付けます、だと今後変化があると問題

☆ そもそも crontab 使っている先駆者いるなら、そっちを参考にすべきではある。

<br>
<h3> 備忘録 </h3> 

[spring では]
* org.springframework.scheduling.support.CronSequenceGenerator で文字列 parse
* 各々のフィールド (月/月内の日/曜日/時/分/秒) に parse 結果を設定
  - 実施時間が全て入っているイメージ
  ※ 仮に 5 秒づつループする設定をした場合、以下の設定が入る。
  > 月 (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
  > 月内の日 (1, 2, 3, 4, 5, ～～～ 31)
  > 曜日 (0, 1, 2, 3, 4, 5, 6)
  > 時 (0, 1, 2, 3, 4, 5, 6, 7 ～～～ 23)
  > 分 (1, 2, 3, 4, 5, 6, 7, 8 ～～～ 60)
  > 秒 (0, 5, 10, 15, 20, 25, 30 ～～ 60) ※ ここが 5 秒間隔

* org.springframework.scheduling.support.CronTrigger が↑のインスタンスをコンポジ
* org.springframework.scheduling.config.CronTask が↑のインスタンスをコンポジ
* その Task を scheduler が実施

[java では]
http://www.quartz-scheduler.org/documentation/quartz-2.3.0/

[quartz]
https://www.slideshare.net/chibochibo/quartzcron
※ 独自で cron scheduling して task 走らせることもできそう
注: Apache License, Version 2.0  なので、どこかに表記が必要
参考: https://vividcode.hatenablog.com/entry/license/android-app-with-apache-license-2.0
